### PR TITLE
adding Leap-2.2.4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RPM_INSTALL_ARG  += --nodigest
 RPM_INSTALL_ARG  += --nodeps
 RPM_INSTALL_ARG  += --nomd5
 
-SPECS             = Leap-2.2.3
+SPECS             = Leap-2.2.4
 
 all:
 	mkdir -p $(RPM_WORKING)/{BUILD,RPMS,SOURCES,SPECS,SRPMS,BROOT}

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 leap-fedora-rpm
 ===============
 
-## 2.2.3+25971 ##
+## 2.2.4+26750 ##
 
 ![](http://oi62.tinypic.com/iqxvk2.jpg "")
 

--- a/SOURCES/Leap-2.2.4/lib/systemd/system/leap.service
+++ b/SOURCES/Leap-2.2.4/lib/systemd/system/leap.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=LeapMotion Daemon
+After=syslog.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/leapd
+
+[Install]
+WantedBy=multi-user.target

--- a/SPECS/Leap-2.2.4.spec
+++ b/SPECS/Leap-2.2.4.spec
@@ -1,5 +1,3 @@
-%define _unpackaged_files_terminate_build 0
-
 %define _topdir %(pwd)
 %define _builddir %{_topdir}/BUILD
 %define _rpmdir %{_topdir}/RPMS
@@ -18,8 +16,8 @@ Autoprov: 0
 Autoreq: 0
 
 # define leap version and release
-%define _leap_version 2.2.3
-%define _leap_release 25971
+%define _leap_version 2.2.4
+%define _leap_release 26750
 
 Summary: Leap Motion re-packaging.
 Name: Leap
@@ -105,6 +103,8 @@ rm -f /etc/systemd/system/leap.service
 %doc
 
 %changelog
+* Tue Mar 31 2015 - makiftasova@gmail.com
+- Leap updated package definition (spec file) for 2.2.4
 * Wed Mar 18 2015 - bugzylittle@gmail.com
 - Leap updated package definition (spec file) for 2.2.3 and fix for 2.2.2
 * Fri Feb 13 2015 - makiftasova@gmail.com


### PR DESCRIPTION
spec files updated for Leap-2.2.4 
also fixed "bogus date warning" on Leap-2.2.3